### PR TITLE
Include inline auth for git: and https: if present.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 'use strict'
 var url = require('url')
 
-var GitHost = exports = module.exports = function (type, user, project, comittish, defaultType) {
+var GitHost = exports = module.exports = function (type, user, auth, project, comittish, defaultType) {
   var gitHostInfo = this
   gitHostInfo.type = type
   Object.keys(gitHosts[type]).forEach(function (key) {
     gitHostInfo[key] = gitHosts[type][key]
   })
   gitHostInfo.user = user
+  gitHostInfo.auth = auth
   gitHostInfo.project = project
   gitHostInfo.comittish = comittish
   gitHostInfo.default = defaultType
@@ -31,10 +32,14 @@ exports.fromUrl = function (giturl) {
   var parsed = parseGitUrl(maybeGitHubShorthand(giturl) ? 'github:' + giturl : giturl)
   var matches = Object.keys(gitHosts).map(function (V) {
     var gitHost = gitHosts[V]
+    var auth = null
+    if (parsed.auth && (parsed.protocol === 'git:' || parsed.protocol === 'https:')) {
+      auth = decodeURIComponent(parsed.auth)
+    }
     var comittish = parsed.hash ? decodeURIComponent(parsed.hash.substr(1)) : null
     if (parsed.protocol === V + ':') {
       return new GitHost(V,
-        decodeURIComponent(parsed.host), decodeURIComponent(parsed.path.replace(/^[/](.*?)(?:[.]git)?$/, '$1')), comittish, 'shortcut')
+        decodeURIComponent(parsed.host), auth, decodeURIComponent(parsed.path.replace(/^[/](.*?)(?:[.]git)?$/, '$1')), comittish, 'shortcut')
     }
     if (parsed.host !== gitHost.domain) return
     if (!gitHost.protocols_re.test(parsed.protocol)) return
@@ -44,6 +49,7 @@ exports.fromUrl = function (giturl) {
     return new GitHost(
       V,
       matched[1] != null && decodeURIComponent(matched[1]),
+      auth,
       matched[2] != null && decodeURIComponent(matched[2]),
       comittish,
       protocolToType(parsed.protocol))
@@ -89,7 +95,7 @@ var gitHostDefaults = {
   'sshurltemplate': 'git+ssh://git@{domain}/{user}/{project}.git{#comittish}',
   'browsetemplate': 'https://{domain}/{user}/{project}{/tree/comittish}',
   'docstemplate': 'https://{domain}/{user}/{project}{/tree/comittish}#readme',
-  'httpstemplate': 'git+https://{domain}/{user}/{project}.git{#comittish}',
+  'httpstemplate': 'git+https://{auth@}{domain}/{user}/{project}.git{#comittish}',
   'filetemplate': 'https://{domain}/{user}/{project}/raw/{comittish}/{path}',
   'shortcuttemplate': '{type}:{user}/{project}{#comittish}',
   'pathtemplate': '{user}/{project}{#comittish}',
@@ -102,9 +108,9 @@ var gitHosts = {
     'protocols': [ 'git', 'http', 'git+ssh', 'git+https', 'ssh', 'https' ],
     'domain': 'github.com',
     'treepath': 'tree',
-    'filetemplate': 'https://raw.githubusercontent.com/{user}/{project}/{comittish}/{path}',
+    'filetemplate': 'https://{auth@}raw.githubusercontent.com/{user}/{project}/{comittish}/{path}',
     'bugstemplate': 'https://{domain}/{user}/{project}/issues',
-    'gittemplate': 'git://{domain}/{user}/{project}.git{#comittish}'
+    'gittemplate': 'git://{auth@}{domain}/{user}/{project}.git{#comittish}'
   },
   bitbucket: {
     'protocols': [ 'git+ssh', 'git+https', 'ssh', 'https' ],
@@ -151,8 +157,10 @@ GitHost.prototype._fill = function (template, vars) {
   if (!vars) vars = {}
   var self = this
   Object.keys(this).forEach(function (K) { if (self[K] != null && vars[K] == null) vars[K] = self[K] })
+  var rawAuth = vars.auth
   var rawComittish = vars.comittish
   Object.keys(vars).forEach(function (K) { (K[0] !== '#') && (vars[K] = encodeURIComponent(vars[K])) })
+  vars['auth@'] = rawAuth ? rawAuth + '@' : ''
   vars['#comittish'] = rawComittish ? '#' + rawComittish : ''
   vars['/tree/comittish'] = vars.comittish ? '/' + vars.treepath + '/' + vars.comittish : ''
   vars['/comittish'] = vars.comittish ? '/' + vars.comittish : ''

--- a/test/https-with-inline-auth.js
+++ b/test/https-with-inline-auth.js
@@ -1,0 +1,34 @@
+'use strict'
+var HostedGit = require('../index')
+var test = require('tap').test
+
+test('HTTPS GitHub URL with embedded auth -- generally not a good idea', function (t) {
+  function verify (host, label, branch) {
+    var hostinfo = HostedGit.fromUrl(host)
+    var hash = branch ? '#' + branch : ''
+    t.ok(hostinfo, label)
+    if (!hostinfo) return
+    t.is(hostinfo.https(), 'git+https://user:pass@github.com/111/222.git' + hash, label + ' -> https')
+    t.is(hostinfo.git(), 'git://user:pass@github.com/111/222.git' + hash, label + ' -> git')
+    t.is(hostinfo.browse(), 'https://github.com/111/222' + (branch ? '/tree/' + branch : ''), label + ' -> browse')
+    t.is(hostinfo.bugs(), 'https://github.com/111/222/issues', label + ' -> bugs')
+    t.is(hostinfo.docs(), 'https://github.com/111/222' + (branch ? '/tree/' + branch : '') + '#readme', label + ' -> docs')
+    t.is(hostinfo.ssh(), 'git@github.com:111/222.git' + hash, label + ' -> ssh')
+    t.is(hostinfo.sshurl(), 'git+ssh://git@github.com/111/222.git' + hash, label + ' -> sshurl')
+    t.is(hostinfo.shortcut(), 'github:111/222' + hash, label + ' -> shortcut')
+    t.is(hostinfo.file('C'), 'https://user:pass@raw.githubusercontent.com/111/222/' + (branch || 'master') + '/C', label + ' -> file')
+  }
+
+  // insecure protocols
+  verify('git://user:pass@github.com/111/222', 'git')
+  verify('git://user:pass@github.com/111/222.git', 'git.git')
+  verify('git://user:pass@github.com/111/222#branch', 'git#branch', 'branch')
+  verify('git://user:pass@github.com/111/222.git#branch', 'git.git#branch', 'branch')
+
+  verify('https://user:pass@github.com/111/222', 'https')
+  verify('https://user:pass@github.com/111/222.git', 'https.git')
+  verify('https://user:pass@github.com/111/222#branch', 'https#branch', 'branch')
+  verify('https://user:pass@github.com/111/222.git#branch', 'https.git#branch', 'branch')
+
+  t.end()
+})


### PR DESCRIPTION
Sets it in `git:` and `https:` URLs, as well as GitHub raw page paths (although I'm not sure that's something GitHub even supports anymore).

**r**: @iarna