### PR TITLE
Use files stanza in package.json to exclude tests from publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,10 @@
   "devDependencies": {
     "standard": "^3.3.2",
     "tap": "^0.4.13"
-  }
+  },
+  "files": [
+    "git-host-info.js",
+    "git-host.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
This came up recently in https://github.com/yargs/yargs/issues/468#issuecomment-206442013.

Would be nice to trim the package size a bit by excluding tests, and I prefer whitelisting files in `package.json` over blacklisting files in `.npmignore`, but I can be persuaded otherwise.

Here is the result of `npm pack` before and after this change:

```
# BEFORE
x package/package.json
x package/.npmignore
x package/README.md
x package/LICENSE
x package/git-host-info.js
x package/git-host.js
x package/index.js
x package/.travis.yml
x package/test/basic.js
x package/test/bitbucket-https-with-embedded-auth.js
x package/test/bitbucket.js
x package/test/gist.js
x package/test/github.js
x package/test/gitlab.js
x package/test/https-with-inline-auth.js
x package/test/lib/standard-tests.js

# AFTER
x package/package.json
x package/README.md
x package/LICENSE
x package/git-host-info.js
x package/git-host.js
x package/index.js
```