### PR TITLE
keep the casing of the owner name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,36 @@
-# hosted-git-info
+<!--@'# ' + package.name + ' ' + shields.flatSquare('npm', 'travis')-->
+# hosted-git-info [![NPM version](https://img.shields.io/npm/v/hosted-git-info.svg?style=flat-square)](https://www.npmjs.com/package/hosted-git-info) [![Build status for master](https://img.shields.io/travis/npm/hosted-git-info/master.svg?style=flat-square)](https://travis-ci.org/npm/hosted-git-info)
+<!--/@-->
+
+<!--@package.description-->
+Provides metadata and conversions from repository urls for Github, Bitbucket and Gitlab
+<!--/@-->
 
 This will let you identify and transform various git hosts URLs between
-protocols.  It also can tell you what the URL is for the raw path for
+protocols. It also can tell you what the URL is for the raw path for
 particular file for direct access without git.
+
+<!--@installation()-->
+## Installation
+
+This module is installed via npm:
+
+```sh
+npm install hosted-git-info --save
+```
+<!--/@-->
 
 ## Usage
 
-```javascript
-var hostedGitInfo = require("hosted-git-info")
-var info = hostedGitInfo.fromUrl("git@github.com:npm/hosted-git-info.git")
-/* info looks like:
-{
-  type: "github",
-  domain: "github.com",
-  user: "npm",
-  project: "hosted-git-info"
-}
-*/
+<!--@example('example.js')-->
+```js
+var hostedGitInfo = require('hosted-git-info')
+var info = hostedGitInfo.fromUrl('git@github.com:npm/hosted-git-info.git')
+console.log([info.type, info.domain, info.user, info.project].join('\n'))
+//> github
+//  github.com
+//  npm
+//  hosted-git-info
 ```
 
 If the URL can't be matched with a git host, `null` will be returned.  We
@@ -24,76 +38,83 @@ can match git, ssh and https urls.  Additionally, we can match ssh connect
 strings (`git@github.com:npm/hosted-git-info`) and shortcuts (eg,
 `github:npm/hosted-git-info`).  Github specifically, is detected in the case
 of a third, unprefixed, form: `npm/hosted-git-info`.
-
 If it does match, the returned object has properties of:
 
-* info.type -- The short name of the service
-* info.domain -- The domain for git protocol use
-* info.user -- The name of the user/org on the git host
-* info.project -- The name of the project on the git host
+- info.type -- The short name of the service
+- info.domain -- The domain for git protocol use
+- info.user -- The name of the user/org on the git host
+- info.project -- The name of the project on the git host
+  And methods of:
+- info.file(path)
+  Given the path of a file relative to the repository, returns a URL for
+  directly fetching it from the githost.  If no committish was set then
+  `master` will be used as the default.
+  For example
 
-And methods of:
+```js
+var url = hostedGitInfo.fromUrl('git@github.com:npm/hosted-git-info.git#v1.0.0').file('package.json')
+console.log(url)
+//> https://raw.githubusercontent.com/npm/hosted-git-info/v1.0.0/package.json
 
-* info.file(path)
+console.log(info.shortcut())
+//> github:npm/hosted-git-info
 
-Given the path of a file relative to the repository, returns a URL for
-directly fetching it from the githost.  If no committish was set then
-`master` will be used as the default.
+console.log(info.browse())
+//> https://github.com/npm/hosted-git-info
 
-For example `hostedGitInfo.fromUrl("git@github.com:npm/hosted-git-info.git#v1.0.0").file("package.json")`
-would return `https://raw.githubusercontent.com/npm/hosted-git-info/v1.0.0/package.json`
+console.log(info.bugs())
+//> https://github.com/npm/hosted-git-info/issues
 
-* info.shortcut()
+console.log(info.docs())
+//> https://github.com/npm/hosted-git-info#readme
 
-eg, `github:npm/hosted-git-info`
+console.log(info.https())
+//> git+https://github.com/npm/hosted-git-info.git
 
-* info.browse()
+console.log(info.sshurl())
+//> git+ssh://git@github.com/npm/hosted-git-info.git
 
-eg, `https://github.com/npm/hosted-git-info/tree/v1.2.0`
+console.log(info.ssh())
+//> git@github.com:npm/hosted-git-info.git
 
-* info.bugs()
+console.log(info.path())
+//> npm/hosted-git-info
 
-eg, `https://github.com/npm/hosted-git-info/issues`
-
-* info.docs()
-
-eg, `https://github.com/npm/hosted-git-info/tree/v1.2.0#readme`
-
-* info.https()
-
-eg, `git+https://github.com/npm/hosted-git-info.git`
-
-* info.sshurl()
-
-eg, `git+ssh://git@github.com/npm/hosted-git-info.git`
-
-* info.ssh()
-
-eg, `git@github.com:npm/hosted-git-info.git`
-
-* info.path()
-
-eg, `npm/hosted-git-info`
-
-* info.getDefaultRepresentation()
+console.log(info.getDefaultRepresentation())
+//> sshurl
+```
 
 Returns the default output type. The default output type is based on the
 string you passed in to be parsed
 
-* info.toString()
+- info.toString()
+  Uses the getDefaultRepresentation to call one of the other methods to get a URL for
+  this resource. As such `hostedGitInfo.fromUrl(url).toString()` will give
+  you a normalized version of the URL that still uses the same protocol.
+  Shortcuts will still be returned as shortcuts, but the special case github
+  form of `org/project` will be normalized to `github:org/project`.
+  SSH connect strings will be normalized into `git+ssh` URLs.
 
-Uses the getDefaultRepresentation to call one of the other methods to get a URL for
-this resource. As such `hostedGitInfo.fromUrl(url).toString()` will give
-you a normalized version of the URL that still uses the same protocol.
-
-Shortcuts will still be returned as shortcuts, but the special case github
-form of `org/project` will be normalized to `github:org/project`.
-
-SSH connect strings will be normalized into `git+ssh` URLs.
-
+<!--/@-->
 
 ## Supported hosts
 
 Currently this supports Github, Bitbucket and Gitlab. Pull requests for
 additional hosts welcome.
 
+<!--@license()-->
+## License
+
+[ISC](./LICENSE) © [Rebecca Turner](http://re-becca.org)
+<!--/@-->
+
+* * *
+
+<!--@devDependencies({ shield: 'flat-square' })-->
+## <a name="dev-dependencies">Dev Dependencies</a> [![devDependency status for master](https://img.shields.io/david/dev/npm/hosted-git-info/master.svg?style=flat-square)](https://david-dm.org/npm/hosted-git-info/master#info=devDependencies)
+
+- [mos](https://github.com/zkochan/mos): A pluggable module that injects content into your markdown files via hidden JavaScript snippets
+- [standard](https://github.com/feross/standard): JavaScript Standard Style
+- [tap](https://github.com/isaacs/node-tap): A Test-Anything-Protocol library
+
+<!--/@-->

--- a/example.js
+++ b/example.js
@@ -1,0 +1,65 @@
+var hostedGitInfo = require('.')
+var info = hostedGitInfo.fromUrl('git@github.com:npm/hosted-git-info.git')
+console.log([info.type, info.domain, info.user, info.project].join('\n'))
+
+/*!
+If the URL can't be matched with a git host, `null` will be returned.  We
+can match git, ssh and https urls.  Additionally, we can match ssh connect
+strings (`git@github.com:npm/hosted-git-info`) and shortcuts (eg,
+`github:npm/hosted-git-info`).  Github specifically, is detected in the case
+of a third, unprefixed, form: `npm/hosted-git-info`.
+
+If it does match, the returned object has properties of:
+
+* info.type -- The short name of the service
+* info.domain -- The domain for git protocol use
+* info.user -- The name of the user/org on the git host
+* info.project -- The name of the project on the git host
+
+And methods of:
+
+* info.file(path)
+
+Given the path of a file relative to the repository, returns a URL for
+directly fetching it from the githost.  If no committish was set then
+`master` will be used as the default.
+
+For example
+*/
+
+var url = hostedGitInfo.fromUrl('git@github.com:npm/hosted-git-info.git#v1.0.0').file('package.json')
+console.log(url)
+
+console.log(info.shortcut())
+
+console.log(info.browse())
+
+console.log(info.bugs())
+
+console.log(info.docs())
+
+console.log(info.https())
+
+console.log(info.sshurl())
+
+console.log(info.ssh())
+
+console.log(info.path())
+
+console.log(info.getDefaultRepresentation())
+
+/*!
+Returns the default output type. The default output type is based on the
+string you passed in to be parsed
+
+* info.toString()
+
+Uses the getDefaultRepresentation to call one of the other methods to get a URL for
+this resource. As such `hostedGitInfo.fromUrl(url).toString()` will give
+you a normalized version of the URL that still uses the same protocol.
+
+Shortcuts will still be returned as shortcuts, but the special case github
+form of `org/project` will be normalized to `github:org/project`.
+
+SSH connect strings will be normalized into `git+ssh` URLs.
+*/

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var authProtocols = {
 module.exports.fromUrl = function (giturl) {
   if (giturl == null || giturl === '') return
   var url = fixupUnqualifiedGist(
-    isGitHubShorthand(giturl) ? 'github:' + giturl : giturl
+    isGitHubShorthand(giturl) ? 'git@github.com:' + giturl : giturl
   )
   var parsed = parseGitUrl(url)
   var matches = Object.keys(gitHosts).map(function (gitHostName) {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   },
   "homepage": "https://github.com/npm/hosted-git-info",
   "scripts": {
-    "test": "standard && tap test/*.js"
+    "test": "standard && tap test/*.js && mos test",
+    "md": "mos"
   },
   "devDependencies": {
+    "mos": "^0.15.0",
     "standard": "^3.3.2",
     "tap": "^0.4.13"
   }

--- a/test/github.js
+++ b/test/github.js
@@ -38,3 +38,8 @@ test('fromUrl(github url)', function (t) {
 
   t.end()
 })
+
+test('github URL casing', function (t) {
+  t.is(HostedGit.fromUrl('Visionmedia/Expresss').browse(), 'https://github.com/Visionmedia/Expresss')
+  t.end()
+})


### PR DESCRIPTION
keep the casing of the owner name in the normalized GitHub repo URL

close #16
