### PR TITLE
Tarball URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ eg, `git@github.com:npm/hosted-git-info.git`
 
 eg, `npm/hosted-git-info`
 
+* info.tarball()
+
+eg, `https://github.com/npm/hosted-git-info/archive/v1.2.0.tar.gz`
+
 * info.getDefaultRepresentation()
 
 Returns the default output type. The default output type is based on the

--- a/git-host-info.js
+++ b/git-host-info.js
@@ -9,19 +9,22 @@ var gitHosts = module.exports = {
     'treepath': 'tree',
     'filetemplate': 'https://{auth@}raw.githubusercontent.com/{user}/{project}/{committish}/{path}',
     'bugstemplate': 'https://{domain}/{user}/{project}/issues',
-    'gittemplate': 'git://{auth@}{domain}/{user}/{project}.git{#committish}'
+    'gittemplate': 'git://{auth@}{domain}/{user}/{project}.git{#committish}',
+    'tarballtemplate': 'https://{domain}/{user}/{project}/archive/{committish}.tar.gz'
   },
   bitbucket: {
     'protocols': [ 'git+ssh', 'git+https', 'ssh', 'https' ],
     'domain': 'bitbucket.org',
-    'treepath': 'src'
+    'treepath': 'src',
+    'tarballtemplate': 'https://{domain}/{user}/{project}/get/{committish}.tar.gz'
   },
   gitlab: {
     'protocols': [ 'git+ssh', 'git+https', 'ssh', 'https' ],
     'domain': 'gitlab.com',
     'treepath': 'tree',
     'docstemplate': 'https://{domain}/{user}/{project}{/tree/committish}#README',
-    'bugstemplate': 'https://{domain}/{user}/{project}/issues'
+    'bugstemplate': 'https://{domain}/{user}/{project}/issues',
+    'tarballtemplate': 'https://{domain}/{user}/{project}/repository/archive.tar.gz?ref={committish}'
   },
   gist: {
     'protocols': [ 'git', 'git+ssh', 'git+https', 'ssh', 'https' ],
@@ -36,7 +39,8 @@ var gitHosts = module.exports = {
     'docstemplate': 'https://{domain}/{project}{/committish}',
     'httpstemplate': 'git+https://{domain}/{project}.git{#committish}',
     'shortcuttemplate': '{type}:{project}{#committish}',
-    'pathtemplate': '{project}{#committish}'
+    'pathtemplate': '{project}{#committish}',
+    'tarballtemplate': 'https://{domain}/{user}/{project}/archive/{committish}.tar.gz'
   }
 }
 

--- a/git-host.js
+++ b/git-host.js
@@ -81,6 +81,10 @@ GitHost.prototype.path = function () {
   return this._fill(this.pathtemplate)
 }
 
+GitHost.prototype.tarball = function () {
+  return this._fill(this.tarballtemplate)
+}
+
 GitHost.prototype.file = function (P) {
   return this._fill(this.filetemplate, {
     path: P.replace(/^[/]+/g, '')

--- a/test/bitbucket.js
+++ b/test/bitbucket.js
@@ -15,6 +15,7 @@ test('fromUrl(bitbucket url)', function (t) {
     t.is(hostinfo.sshurl(), 'git+ssh://git@bitbucket.org/111/222.git' + hash, label + ' -> sshurl')
     t.is(hostinfo.shortcut(), 'bitbucket:111/222' + hash, label + ' -> shortcut')
     t.is(hostinfo.file('C'), 'https://bitbucket.org/111/222/raw/' + (branch || 'master') + '/C', label + ' -> file')
+    t.is(hostinfo.tarball(), 'https://bitbucket.org/111/222/get/' + (branch || 'master') + '.tar.gz', label + ' -> tarball')
   }
 
   require('./lib/standard-tests')(verify, 'bitbucket.org', 'bitbucket')

--- a/test/gist.js
+++ b/test/gist.js
@@ -18,6 +18,7 @@ test('fromUrl(gist url)', function (t) {
     t.is(hostinfo.shortcut(), 'gist:222' + hash, label + ' -> shortcut')
     if (hostinfo.user) {
       t.is(hostinfo.file('C'), 'https://gist.githubusercontent.com/111/222/raw/' + (branch ? branch + '/' : '') + 'C', label + ' -> file')
+      t.is(hostinfo.tarball(), 'https://gist.github.com/111/222/archive/' + (branch || 'master') + '.tar.gz', label + ' -> tarball')
     }
   }
 

--- a/test/github.js
+++ b/test/github.js
@@ -17,6 +17,7 @@ test('fromUrl(github url)', function (t) {
     t.is(hostinfo.sshurl(), 'git+ssh://git@github.com/111/222.git' + hash, label + ' -> sshurl')
     t.is(hostinfo.shortcut(), 'github:111/222' + hash, label + ' -> shortcut')
     t.is(hostinfo.file('C'), 'https://raw.githubusercontent.com/111/222/' + (branch || 'master') + '/C', label + ' -> file')
+    t.is(hostinfo.tarball(), 'https://github.com/111/222/archive/' + (branch || 'master') + '.tar.gz', label + ' -> tarball')
   }
 
   // github shorturls

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -15,6 +15,7 @@ test('fromUrl(gitlab url)', function (t) {
     t.is(hostinfo.sshurl(), 'git+ssh://git@gitlab.com/111/222.git' + hash, label + ' -> sshurl')
     t.is(hostinfo.shortcut(), 'gitlab:111/222' + hash, label + ' -> shortcut')
     t.is(hostinfo.file('C'), 'https://gitlab.com/111/222/raw/' + (branch || 'master') + '/C', label + ' -> file')
+    t.is(hostinfo.tarball(), 'https://gitlab.com/111/222/repository/archive.tar.gz?ref=' + (branch || 'master'), label + ' -> tarball')
   }
 
   require('./lib/standard-tests')(verify, 'gitlab.com', 'gitlab')


### PR DESCRIPTION
All the hosted git services this package supports have individual tarball URLs that can be used to download the source directly (without git).