### PR TITLE
11% npm install speed increase: add caching to fromUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,19 @@ var authProtocols = {
   'git+http:': true
 }
 
+var cache = {}
+
 module.exports.fromUrl = function (giturl, opts) {
+  var key = giturl + JSON.stringify(opts || {})
+
+  if (!(key in cache)) {
+    cache[key] = fromUrl(giturl, opts)
+  }
+
+  return cache[key]
+}
+
+function fromUrl (giturl, opts) {
   if (giturl == null || giturl === '') return
   var url = fixupUnqualifiedGist(
     isGitHubShorthand(giturl) ? 'github:' + giturl : giturl


### PR DESCRIPTION
## TL:DR
~11% speed up in the average npm install run

## Details
You would not believe how often fromUrl gets hit in the average `npm i` run. On a fairly large private project that installs 1764 packages, if I track number of cache hits and misses, I get:

### Hit rate:

```
miss 5713
hit  240941
```

This translates to build times (w package-lock.json but without a node_modules dir, which is common in CI runs) of:

### Before:
```
added 1764 packages in 51.943s
added 1764 packages in 51.135s
added 1764 packages in 50.688s
added 1764 packages in 52.048s
added 1764 packages in 52.156s
added 1764 packages in 54.817s
```
### After
```
added 1764 packages in 46.1s
added 1764 packages in 47.784s
added 1764 packages in 49.382s
```