### PR TITLE
Remove Object.assign fallback

### DIFF
--- a/git-host.js
+++ b/git-host.js
@@ -1,6 +1,5 @@
 'use strict'
 var gitHosts = require('./git-host-info.js')
-var extend = Object.assign
 
 var GitHost = module.exports = function (type, user, auth, project, committish, defaultRepresentation, opts) {
   var gitHostInfo = this
@@ -23,8 +22,8 @@ GitHost.prototype.hash = function () {
 
 GitHost.prototype._fill = function (template, opts) {
   if (!template) return
-  var vars = extend({}, opts)
-  opts = extend(extend({}, this.opts), opts)
+  var vars = Object.assign({}, opts)
+  opts = Object.assign({}, this.opts, opts)
   var self = this
   Object.keys(this).forEach(function (key) {
     if (self[key] != null && vars[key] == null) vars[key] = self[key]
@@ -100,7 +99,7 @@ GitHost.prototype.tarball = function (opts) {
 }
 
 GitHost.prototype.file = function (P, opts) {
-  return this._fill(this.filetemplate, extend({
+  return this._fill(this.filetemplate, Object.assign({
     path: P.replace(/^[/]+/g, '')
   }, opts))
 }

--- a/git-host.js
+++ b/git-host.js
@@ -1,6 +1,6 @@
 'use strict'
 var gitHosts = require('./git-host-info.js')
-var extend = Object.assign || require('util')._extend
+var extend = Object.assign
 
 var GitHost = module.exports = function (type, user, auth, project, committish, defaultRepresentation, opts) {
   var gitHostInfo = this

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "bitbucket",
     "gitlab"
   ],
+  "engines": {
+    "node": ">=4"
+  },
   "author": "Rebecca Turner <me@re-becca.org> (http://re-becca.org)",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
Node 4+, like `.travis.yml` is configured to test.

This is useful to keep the browserified bundle size down by excluding a package/method that is no longer used anywhere (`util/_extend`)

80KB -> 58KB (28%)

`standard@10.0` also includes this suggestion:

```
git-host.js:3:31: 'util._extend' was deprecated since v6. Use 'Object.assign()' instead. (node/no-deprecated-api)
```