### PR TITLE
Replace url module with lighter self-contained parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict'
-var url = require('url')
+var url = require('./reduced-url')
 var gitHosts = require('./git-host-info.js')
 var GitHost = module.exports = require('./git-host.js')
 

--- a/reduced-url.js
+++ b/reduced-url.js
@@ -1,0 +1,23 @@
+var protocol = '(?:([^:]+:)?(?://)?)?'
+var auth = '(?:(\\S+(?::\\S*)?)@)?'
+var host = '([^/:]*)'
+var path = '([/]?[^#]*)'
+var hash = '(#.+)?'
+var urlLaxRegex = new RegExp(protocol + auth + host + path + hash)
+
+module.exports.parse = function (url) {
+  var match = url.match(urlLaxRegex)
+  if (match) {
+    var path = match[4]
+    if (path && path[0] !== '/') {
+      path = '/' + path
+    }
+    return {
+      protocol: match[1],
+      auth: match[2],
+      host: match[3],
+      path: path,
+      hash: match[5]
+    }
+  }
+}


### PR DESCRIPTION
Makes the package lighter in both node and the browser.

80KB -> 36KB (saves 55%)

80KB -> 13KB (saves 83% when combined with #25)

I was initially going to keep this as a fork, considering that using `url` might be preferred in node, but seeing that there are 1127 passing tests I thought of making a PR instead.