### PR TITLE
Add support for self-hosted git using the 'generic' type

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,8 @@ SSH connect strings will be normalized into `git+ssh` URLs.
 
 ## Supported hosts
 
-Currently this supports Github, Bitbucket and Gitlab. Pull requests for
-additional hosts welcome.
+Github, Bitbucket and Gitlab are fully supported. For URLs to hosts that
+include at least a username and project name, the type 'generic' is returned
+which is a best-effort guess that should support most self-hosted servers.
+
+Pull requests for additional hosts welcome.

--- a/git-host-info.js
+++ b/git-host-info.js
@@ -45,6 +45,16 @@ var gitHosts = module.exports = {
     'hashformat': function (fragment) {
       return 'file-' + formatHashFragment(fragment)
     }
+  },
+  generic: {
+    'protocols': [ 'git', 'http', 'git+ssh', 'git+https', 'ssh', 'https' ],
+    'domain': '*',
+    'treepath': 'tree',
+    'sshtemplate': 'git@{domain}:{user}/{project}.git{#committish}',
+    'sshurltemplate': 'git+ssh://git@{domain}/{user}/{project}.git{#committish}',
+    'httpstemplate': 'git+https://{auth@}{domain}/{user}/{project}.git{#committish}',
+    'gittemplate': 'git://{auth@}{domain}/{user}/{project}.git{#committish}',
+    'pathmatch': /^[/]([^/]+)[/]([^/]+?)(?:[.]git|[/])?$/
   }
 }
 
@@ -64,7 +74,7 @@ var gitHostDefaults = {
 
 Object.keys(gitHosts).forEach(function (name) {
   Object.keys(gitHostDefaults).forEach(function (key) {
-    if (gitHosts[name][key]) return
+    if (gitHosts[name][key] || name === 'generic') return
     gitHosts[name][key] = gitHostDefaults[key]
   })
   gitHosts[name].protocols_re = RegExp('^(' +

--- a/test/basic.js
+++ b/test/basic.js
@@ -13,8 +13,6 @@ test('basic', function (t) {
   t.is(HostedGit.fromUrl('git://github.com/abc/def').getDefaultRepresentation(), 'git', 'match git urls')
   t.is(HostedGit.fromUrl('github:abc/def').getDefaultRepresentation(), 'shortcut', 'match shortcuts')
 
-  t.is(HostedGit.fromUrl('git+ssh://git@nothosted.com/abc/def'), undefined, 'non-hosted URLs get undefined response')
-  t.is(HostedGit.fromUrl('git://nothosted.com'), undefined, 'non-hosted empty URLs get undefined response')
   t.is(HostedGit.fromUrl('git://github.com/balderdashy/waterline-%s.git'), undefined, 'invalid URLs get undefined response')
   t.is(HostedGit.fromUrl('git://github.com'), undefined, 'Invalid hosted URLs get undefined response')
 

--- a/test/generic.js
+++ b/test/generic.js
@@ -1,0 +1,31 @@
+'use strict'
+var HostedGit = require('../index')
+var test = require('tap').test
+
+test('fromUrl(generic url)', function (t) {
+  function verify (host, label, branch) {
+    var hostinfo = HostedGit.fromUrl(host)
+    var hash = branch ? '#' + branch : ''
+    t.ok(hostinfo, label)
+    if (!hostinfo) return
+    t.is(hostinfo.https(), 'git+https://generic.com/111/222.git' + hash, label + ' -> https')
+    t.is(hostinfo.git(), 'git://generic.com/111/222.git' + hash, label + ' -> git')
+    t.is(hostinfo.ssh(), 'git@generic.com:111/222.git' + hash, label + ' -> ssh')
+    t.is(hostinfo.sshurl(), 'git+ssh://git@generic.com/111/222.git' + hash, label + ' -> sshurl')
+  }
+
+  // insecure protocols
+  verify('git://generic.com/111/222', 'git')
+  verify('git://generic.com/111/222.git', 'git.git')
+  verify('git://generic.com/111/222#branch', 'git#branch', 'branch')
+  verify('git://generic.com/111/222.git#branch', 'git.git#branch', 'branch')
+
+  verify('http://generic.com/111/222', 'http')
+  verify('http://generic.com/111/222.git', 'http.git')
+  verify('http://generic.com/111/222#branch', 'http#branch', 'branch')
+  verify('http://generic.com/111/222.git#branch', 'http.git#branch', 'branch')
+
+  require('./lib/standard-tests')(verify, 'generic.com', 'generic')
+
+  t.end()
+})

--- a/test/lib/standard-tests.js
+++ b/test/lib/standard-tests.js
@@ -20,8 +20,10 @@ module.exports = function (verify, domain, shortname) {
   verify('git+ssh://git@' + domain + '/111/222#branch', 'ssh url#branch', 'branch')
   verify('git+ssh://git@' + domain + '/111/222.git#branch', 'ssh url.git#branch', 'branch')
 
-  verify(shortname + ':111/222', 'shortcut')
-  verify(shortname + ':111/222.git', 'shortcut.git')
-  verify(shortname + ':111/222#branch', 'shortcut#branch', 'branch')
-  verify(shortname + ':111/222.git#branch', 'shortcut.git#branch', 'branch')
+  if (shortname !== 'generic') {
+    verify(shortname + ':111/222', 'shortcut')
+    verify(shortname + ':111/222.git', 'shortcut.git')
+    verify(shortname + ':111/222#branch', 'shortcut#branch', 'branch')
+    verify(shortname + ':111/222.git#branch', 'shortcut.git#branch', 'branch')
+  }
 }


### PR DESCRIPTION
URLs that contain at least 'user' and 'project' will be parsed as the new type 'generic'. This URL scheme should support many self-hosted git services like for example:

- gitlab
- gitea
- gogs

The change itself should be considered semver-major as some users may rely on the previous 'undefined' values that were returned.