### PR TITLE
chore: update github tarballtemplate

### DIFF
--- a/git-host-info.js
+++ b/git-host-info.js
@@ -10,7 +10,7 @@ var gitHosts = module.exports = {
     'filetemplate': 'https://{auth@}raw.githubusercontent.com/{user}/{project}/{committish}/{path}',
     'bugstemplate': 'https://{domain}/{user}/{project}/issues',
     'gittemplate': 'git://{auth@}{domain}/{user}/{project}.git{#committish}',
-    'tarballtemplate': 'https://{domain}/{user}/{project}/archive/{committish}.tar.gz'
+    'tarballtemplate': 'https://codeload.{domain}/{user}/{project}/tar.gz/{committish}'
   },
   bitbucket: {
     'protocols': [ 'git+ssh', 'git+https', 'ssh', 'https' ],

--- a/test/github.js
+++ b/test/github.js
@@ -19,7 +19,7 @@ test('fromUrl(github url)', function (t) {
     t.is(hostinfo.sshurl(), 'git+ssh://git@github.com/111/222.git' + hash, label + ' -> sshurl')
     t.is(hostinfo.shortcut(), 'github:111/222' + hash, label + ' -> shortcut')
     t.is(hostinfo.file('C'), 'https://raw.githubusercontent.com/111/222/' + (branch || 'master') + '/C', label + ' -> file')
-    t.is(hostinfo.tarball(), 'https://github.com/111/222/archive/' + (branch || 'master') + '.tar.gz', label + ' -> tarball')
+    t.is(hostinfo.tarball(), 'https://codeload.github.com/111/222/tar.gz/' + (branch || 'master'), label + ' -> tarball')
   }
 
   // github shorturls


### PR DESCRIPTION
The old tarball url generates a 302 redirect to https://codeload.github.com, it's troublesome for tools (like curl) which do not automatically follow redirect response.