### PR TITLE
Basic Support for GitHub Enterprise

### DIFF
--- a/git-host-info.js
+++ b/git-host-info.js
@@ -53,7 +53,7 @@ var gitHosts = module.exports = {
     'bugstemplate': 'https://{domain}/{user}/{project}/issues',
     'gittemplate': 'git://{auth@}{domain}/{user}/{project}.git{#committish}',
     'tarballtemplate': 'https://{domain}/{user}/{project}/archive/{committish}.tar.gz'
-  },
+  }
 }
 
 var gitHostDefaults = {

--- a/git-host-info.js
+++ b/git-host-info.js
@@ -44,7 +44,16 @@ var gitHosts = module.exports = {
     'hashformat': function (fragment) {
       return 'file-' + formatHashFragment(fragment)
     }
-  }
+  },
+  githubenterprise: {
+    'protocols': [ 'git', 'http', 'git+ssh', 'git+https', 'ssh', 'https' ],
+    'domainpattern': 'github',
+    'treepath': 'tree',
+    'filetemplate': 'https://{auth@}{domain}/raw/{user}/{project}/{committish}/{path}',
+    'bugstemplate': 'https://{domain}/{user}/{project}/issues',
+    'gittemplate': 'git://{auth@}{domain}/{user}/{project}.git{#committish}',
+    'tarballtemplate': 'https://{domain}/{user}/{project}/archive/{committish}.tar.gz'
+  },
 }
 
 var gitHostDefaults = {

--- a/index.js
+++ b/index.js
@@ -59,8 +59,9 @@ function fromUrl (giturl, opts) {
         project = decodeURIComponent(shortcutMatch[3])
         defaultRepresentation = 'shortcut'
       } else {
-        if (parsed.host && parsed.host !== gitHostInfo.domain && parsed.host.replace(/^www[.]/, '') !== gitHostInfo.domain) return
-        if (!gitHostInfo.protocols_re.test(parsed.protocol)) return
+        if (gitHostInfo.domain && parsed.host && parsed.host !== gitHostInfo.domain && parsed.host.replace(/^www[.]/, '') !== gitHostInfo.domain) return
+        if (gitHostInfo.domainpattern && parsed.host && parsed.host.indexOf(gitHostInfo.domainpattern) < 0 && parsed.host.replace(/^www[.]/, '').indexOf(gitHostInfo.domainpattern) < 0) return
+        else gitHostInfo.domain = parsed.host.replace(/^www[.]/, '')        if (!gitHostInfo.protocols_re.test(parsed.protocol)) return
         if (!parsed.path) return
         var pathmatch = gitHostInfo.pathmatch
         var matched = parsed.path.match(pathmatch)

--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ function fromUrl (giturl, opts) {
       } else {
         if (gitHostInfo.domain && parsed.host && parsed.host !== gitHostInfo.domain && parsed.host.replace(/^www[.]/, '') !== gitHostInfo.domain) return
         if (gitHostInfo.domainpattern && parsed.host && parsed.host.indexOf(gitHostInfo.domainpattern) < 0 && parsed.host.replace(/^www[.]/, '').indexOf(gitHostInfo.domainpattern) < 0) return
-        else gitHostInfo.domain = parsed.host.replace(/^www[.]/, '')        if (!gitHostInfo.protocols_re.test(parsed.protocol)) return
+        else gitHostInfo.domain = parsed.host.replace(/^www[.]/, '')
+        if (!gitHostInfo.protocols_re.test(parsed.protocol)) return
         if (!parsed.path) return
         var pathmatch = gitHostInfo.pathmatch
         var matched = parsed.path.match(pathmatch)


### PR DESCRIPTION
This allows to retrieve information for GitHub Enterprise URLs that contain 'github' in their domain, which most of them will do. Potentially closes most of the requests for this.