### PR TITLE
ci(travis): fix failed test for Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ node_js:
   - "8"
   - "6"
   - "4"
+script: |
+  if [ $TRAVIS_NODE_VERSION == "4" ]; then
+    ./node_modules/.bin/tap --no-esm test;
+  else
+    npm test;
+  fi


### PR DESCRIPTION
See [the failed build log](https://travis-ci.org/npm/hosted-git-info/jobs/509276436).

By using `--no-esm` option of `tap` (see https://www.node-tap.org/cli/).

![image](https://user-images.githubusercontent.com/473530/54735964-2fedf600-4bec-11e9-90f6-d8ca6e12f782.png)
