### PR TITLE
Do not URL encode slashes in project name for GitLab https URL

### DIFF
--- a/git-host-info.js
+++ b/git-host-info.js
@@ -23,6 +23,7 @@ var gitHosts = module.exports = {
     'domain': 'gitlab.com',
     'treepath': 'tree',
     'bugstemplate': 'https://{domain}/{user}/{project}/issues',
+    'httpstemplate': 'git+https://{auth@}{domain}/{user}/{projectPath}.git{#committish}',
     'tarballtemplate': 'https://{domain}/{user}/{project}/repository/archive.tar.gz?ref={committish}'
   },
   gist: {

--- a/git-host.js
+++ b/git-host.js
@@ -35,6 +35,7 @@ GitHost.prototype._fill = function (template, opts) {
   var rawcommittish = vars.committish
   var rawFragment = vars.fragment
   var rawPath = vars.path
+  var rawProject = vars.project
   Object.keys(vars).forEach(function (key) {
     vars[key] = encodeURIComponent(vars[key])
   })
@@ -43,6 +44,7 @@ GitHost.prototype._fill = function (template, opts) {
   vars.fragment = vars.fragment ? vars.fragment : ''
   vars['#path'] = rawPath ? '#' + this.hashformat(rawPath) : ''
   vars['/path'] = vars.path ? '/' + vars.path : ''
+  vars.projectPath = rawProject.split('/').map(encodeURIComponent).join('/')
   if (opts.noCommittish) {
     vars['#committish'] = ''
     vars['/tree/committish'] = ''

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -23,5 +23,11 @@ test('fromUrl(gitlab url)', function (t) {
   require('./lib/standard-tests')(verify, 'gitlab.com', 'gitlab')
   require('./lib/standard-tests')(verify, 'www.gitlab.com', 'gitlab')
 
+  t.is(
+    HostedGit.fromUrl('gitlab:group/sub group1/subgroup2/repo').https(),
+    'git+https://gitlab.com/group/sub%20group1/subgroup2/repo.git',
+    'subgroups are delimited with slashes and url encoded (shortcut -> https)'
+  )
+
   t.end()
 })


### PR DESCRIPTION
Suggested fix for #46. I'm happy to take suggestions on alternate fixes.

Some quick testing against GitLab using the ssh URL does not appear to have the same issue. GitLab handles the URL-encoded slashes just fine for ssh.