### PR TITLE
fix: do not encodeURIComponent the domain

### DIFF
--- a/git-host.js
+++ b/git-host.js
@@ -56,7 +56,7 @@ GitHost.prototype._fill = function (template, opts) {
       vars[key] = value.split('/').map(function (pathComponent) {
         return encodeURIComponent(pathComponent)
       }).join('/')
-    } else {
+    } else if (key !== 'domain') {
       vars[key] = encodeURIComponent(value)
     }
   })

--- a/test/localhost.js
+++ b/test/localhost.js
@@ -1,0 +1,29 @@
+// An example of a custom setup, useful when testing modules like pacote,
+// which do various things with these git shortcuts.
+const t = require('tap')
+const ghi = require('../git-host-info.js')
+ghi.localhost = {
+  protocols: [ 'git' ],
+  domain: 'localhost:12345',
+  gittemplate: 'git://{domain}/{user}{#committish}',
+  treepath: 'not-implemented',
+  tarballtemplate: 'http://localhost:18000/repo-HEAD.tgz',
+  shortcuttemplate: '{type}:{user}/x{#committish}',
+  pathtemplate: '/{user}{#committish}',
+  pathmatch: /^\/(repo|submodule-repo)/,
+  hashformat: h => h,
+  protocols_re: /^(git):$/
+}
+
+const gh = require('../')
+const f = gh.fromUrl('git://localhost:12345/repo')
+
+t.ok(f, 'got a localhost "hosted" repo')
+t.equal(f.git(), 'git://localhost:12345/repo')
+t.equal(f.tarball(), 'http://localhost:18000/repo-HEAD.tgz')
+t.equal(f.shortcut(), 'localhost:repo/x')
+
+const g = gh.fromUrl('localhost:repo/x')
+t.ok(g, 'got a localhost repo from shortcut')
+t.equal(g.git(), f.git(), 'resolves to the same repo')
+t.equal(g.tarball(), f.tarball(), 'resolves to same tarball')


### PR DESCRIPTION
I ran into a situation where I have to test how Pacote handles git
shorthands from hosted-git-info, but I didn't want to ping GitHub to run
my tests.

I set up a git daemon and http server on localhost easily enough, but it
was still necessary to make it a 'real' HostedGit for the purposes of
npm-package-arg, and the : with port number was getting URL encoded.

This shows an example of doing this hack/test workaround, and fixes the
encoding issue.

It would be interesting to perhaps support GitHub Enterprise or on-prem
GitLab by letting users specify a prefix and format for hosted git info
in their npm configs, and then clone the definition with a different
domain name.