### PR TITLE
Ensure passwords in hosted Git URLs are correctly escaped

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,8 @@ function parseGitUrl (giturl) {
     var legacy = url.parse(giturl)
     if (legacy.auth) {
       var whatwg = new url.URL(giturl)
-      legacy.auth = whatwg.username + ':' + whatwg.password
+      legacy.auth = whatwg.username || ''
+      if (whatwg.password) legacy.auth += ':' + whatwg.password
     }
     return legacy
   }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function fromUrl (giturl, opts) {
       var gitHostInfo = gitHosts[gitHostName]
       var auth = null
       if (parsed.auth && authProtocols[parsed.protocol]) {
-        auth = decodeURIComponent(parsed.auth)
+        auth = parsed.auth
       }
       var committish = parsed.hash ? decodeURIComponent(parsed.hash.substr(1)) : null
       var user = null
@@ -106,7 +106,14 @@ function fixupUnqualifiedGist (giturl) {
 
 function parseGitUrl (giturl) {
   var matched = giturl.match(/^([^@]+)@([^:/]+):[/]?((?:[^/]+[/])?[^/]+?)(?:[.]git)?(#.*)?$/)
-  if (!matched) return url.parse(giturl)
+  if (!matched) {
+    var legacy = url.parse(giturl)
+    if (legacy.auth) {
+      var whatwg = new url.URL(giturl)
+      legacy.auth = whatwg.username + ':' + whatwg.password
+    }
+    return legacy
+  }
   return {
     protocol: 'git+ssh:',
     slashes: true,

--- a/test/auth.js
+++ b/test/auth.js
@@ -12,3 +12,7 @@ var parsedUrl = new url.URL(parsedInfo.toString())
 tap.equal(parsedUrl.username, 'user%3An%40me')
 tap.equal(parsedUrl.password, 'p%40ss%3Aword')
 tap.equal(parsedUrl.hostname, 'github.com')
+
+// For full backwards-compatibility; support auth where only username or only password is provided
+tap.equal(HostedGitInfo.fromUrl('https://user%3An%40me@github.com/npm/hosted-git-info.git').auth, 'user%3An%40me')
+tap.equal(HostedGitInfo.fromUrl('https://:p%40ss%3Aword@github.com/npm/hosted-git-info.git').auth, ':p%40ss%3Aword')

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,0 +1,14 @@
+var HostedGitInfo = require('../')
+
+var tap = require('tap')
+var url = require('url')
+
+// Auth credentials with special characters (colon and/or at-sign) should remain correctly escaped
+var parsedInfo = HostedGitInfo.fromUrl('https://user%3An%40me:p%40ss%3Aword@github.com/npm/hosted-git-info.git')
+tap.equal(parsedInfo.auth, 'user%3An%40me:p%40ss%3Aword')
+
+// Node.js' built-in `url` module should be able to parse the resulting url
+var parsedUrl = new url.URL(parsedInfo.toString())
+tap.equal(parsedUrl.username, 'user%3An%40me')
+tap.equal(parsedUrl.password, 'p%40ss%3Aword')
+tap.equal(parsedUrl.hostname, 'github.com')


### PR DESCRIPTION
# What
Hosted Git URLs may be specified in the format `protocol://username:password@domain/path`.

However, when the username and/or password contain certain punctuation characters (notably `:` or `@`), this library fails to return the credentials with these characters correctly escaped. **The result is that npm either fails to connect because the hostname has been parsed incorrectly, or fails to authenticate with the host because the credentials have been parsed incorrectly.**

```javascript
const HostedGitInfo = require('hosted-git-info');

const username = 'user:n@me';
const password = 'p@ss:word';
const auth = encodeURIComponent(username) + ':' + encodeURIComponent(password);
const url = 'https://' + auth + '@github.com/npm/hosted-git-info.git';
const parsed = HostedGitInfo.fromUrl(url);

                          // expected: user%3Ana%40me:p%40ss%3Aword
console.log(parsed.auth); // actual: user:na@me:p@ss:word
```

# Why
The reason for this is that the "Legacy" API of Node.js' `url` module *does not* escape these characters in the `auth` property of the parsed URL.

See https://nodejs.org/api/url.html#url_percent_encoding_in_urls for details.

# How
Node.js' newer, WHATWG-compatible API *does* escape the `username` and `password` properties of the parsed URL. The fix that I propose in this PR is to continue using the Legacy API to minimize code changes and therefore risk of regression, but to use the WHATWG API to return the parsed username and password *only* when auth is included in the URL.