### PR TITLE
fix: do not use url.URL to support early node 6 and scp-style URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,9 +109,8 @@ function parseGitUrl (giturl) {
   if (!matched) {
     var legacy = url.parse(giturl)
     if (legacy.auth) {
-      var whatwg = new url.URL(giturl)
-      legacy.auth = whatwg.username || ''
-      if (whatwg.password) legacy.auth += ':' + whatwg.password
+      // Replace the url decoded username:password with the url encoded username:password from the original url
+      legacy.auth = giturl.match(new RegExp('^[^/]+//([^@]+)@'))[1]
     }
     return legacy
   }

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,17 +1,10 @@
 var HostedGitInfo = require('../')
 
 var tap = require('tap')
-var url = require('url')
 
 // Auth credentials with special characters (colon and/or at-sign) should remain correctly escaped
 var parsedInfo = HostedGitInfo.fromUrl('https://user%3An%40me:p%40ss%3Aword@github.com/npm/hosted-git-info.git')
 tap.equal(parsedInfo.auth, 'user%3An%40me:p%40ss%3Aword')
-
-// Node.js' built-in `url` module should be able to parse the resulting url
-var parsedUrl = new url.URL(parsedInfo.toString())
-tap.equal(parsedUrl.username, 'user%3An%40me')
-tap.equal(parsedUrl.password, 'p%40ss%3Aword')
-tap.equal(parsedUrl.hostname, 'github.com')
 
 // For full backwards-compatibility; support auth where only username or only password is provided
 tap.equal(HostedGitInfo.fromUrl('https://user%3An%40me@github.com/npm/hosted-git-info.git').auth, 'user%3An%40me')

--- a/test/basic.js
+++ b/test/basic.js
@@ -35,7 +35,10 @@ test('basic', function (t) {
   t.is(HostedGit.fromUrl(), undefined, 'no value is not hosted')
   t.is(HostedGit.fromUrl('git+file:///foo/bar'), undefined, 'url that has no host')
   t.is(HostedGit.fromUrl('github.com/abc/def/'), undefined, 'forgot the protocol')
+  t.is(HostedGit.fromUrl('//github.com/abc/def/'), undefined, 'forgot the protocol')
   t.is(HostedGit.fromUrl('completely-invalid'), undefined, 'not a url is not hosted')
+
+  t.is(HostedGit.fromUrl('git+ssh://git@git.unlucky.com:RND/electron-tools/some-tool#2.0.1'), undefined, 'properly ignores non-hosted scp style urls')
 
   t.is(HostedGit.fromUrl('http://github.com/foo/bar').toString(), 'git+ssh://git@github.com/foo/bar.git', 'github http protocol use git+ssh urls')
   t.end()


### PR DESCRIPTION
This gets rid of using url.URL, which fixes #60 and #61

This in theory could also be applied to the latest branch.  While node v6 isn't supported in the latest branch, it may be a more elegant fix to #60 than leaving url.URL in place.

