### PR TITLE
fix: support to github gist legacy hash length

### DIFF
--- a/git-host-info.js
+++ b/git-host-info.js
@@ -30,7 +30,7 @@ var gitHosts = module.exports = {
   gist: {
     'protocols': [ 'git', 'git+ssh', 'git+https', 'ssh', 'https' ],
     'domain': 'gist.github.com',
-    'pathmatch': /^[/](?:([^/]+)[/])?([a-z0-9]{32,})(?:[.]git)?$/,
+    'pathmatch': /^[/](?:([^/]+)[/])?([a-z0-9]{7,})(?:[.]git)?$/,
     'filetemplate': 'https://gist.githubusercontent.com/{user}/{project}/raw{/committish}/{path}',
     'bugstemplate': 'https://{domain}/{project}',
     'gittemplate': 'git://{domain}/{project}.git{#committish}',

--- a/test/gist.js
+++ b/test/gist.js
@@ -9,6 +9,7 @@ var testFixtures = function (t, params, fixtures) {
     var fixture = fixtures[i]
     var host = fixture.host(params)
     var hostinfo = HostedGit.fromUrl(host)
+    var expectedHash = params.project
 
     // INFO: from Url should return `undefined` from fixture input
     if (fixture.isUndefined) {
@@ -27,18 +28,18 @@ var testFixtures = function (t, params, fixtures) {
       }
       tt.is(
         hostinfo.https(),
-        expected('git+https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git', fixture.hasBranch),
+        expected(`git+https://gist.github.com/${expectedHash}.git`, fixture.hasBranch),
         showLabel(fixture.label, 'https')
       )
       tt.is(
         hostinfo.https({ noCommittish: true }),
         // INFO: not using `expected` because with `{noCommittish: true}` the output is always the same
-        'git+https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git',
+        `git+https://gist.github.com/${expectedHash}.git`,
         showLabel(fixture.label, 'https({ noCommittish: true })')
       )
       tt.is(
         hostinfo.https({ noGitPlus: true }),
-        expected('https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git', fixture.hasBranch),
+        expected(`https://gist.github.com/${expectedHash}.git`, fixture.hasBranch),
         showLabel(fixture.label, 'https({ noGitPlus: true })')
       )
       tt.end()
@@ -51,18 +52,18 @@ var testFixtures = function (t, params, fixtures) {
       }
       tt.is(
         hostinfo.git(),
-        expected('git://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git', fixture.hasBranch),
+        expected(`git://gist.github.com/${expectedHash}.git`, fixture.hasBranch),
         showLabel(fixture.label, 'git')
       )
       tt.is(
         hostinfo.git({ noCommittish: true }),
         // INFO: not using `expected` because with `{noCommittish: true}` the output is always the same
-        'git://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git',
+        `git://gist.github.com/${expectedHash}.git`,
         showLabel(fixture.label, 'git({ noCommittish: true })')
       )
       tt.is(
         hostinfo.git({ noGitPlus: true }),
-        expected('git://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git', fixture.hasBranch),
+        expected(`git://gist.github.com/${expectedHash}.git`, fixture.hasBranch),
         showLabel(fixture.label, 'git({ noGitPlus: true })')
       )
       tt.end()
@@ -75,27 +76,27 @@ var testFixtures = function (t, params, fixtures) {
       }
       tt.is(
         hostinfo.browse(),
-        expected('https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2', fixture.hasBranch),
+        expected(`https://gist.github.com/${expectedHash}`, fixture.hasBranch),
         showLabel(fixture.label, 'browse')
       )
       tt.is(
         hostinfo.browse('C'),
-        expected('https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2', fixture.hasBranch) + '#file-c',
+        expected(`https://gist.github.com/${expectedHash}`, fixture.hasBranch) + '#file-c',
         showLabel(fixture.label, "browse('C')")
       )
       tt.is(
         hostinfo.browse('C/D'),
-        expected('https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2', fixture.hasBranch) + '#file-cd',
+        expected(`https://gist.github.com/${expectedHash}`, fixture.hasBranch) + '#file-cd',
         showLabel(fixture.label, "browse('C/D')")
       )
       tt.is(
         hostinfo.browse('C', 'A'),
-        expected('https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2', fixture.hasBranch) + '#file-c',
+        expected(`https://gist.github.com/${expectedHash}`, fixture.hasBranch) + '#file-c',
         showLabel(fixture.label, "browse('C', 'A')")
       )
       tt.is(
         hostinfo.browse('C/D', 'A'),
-        expected('https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2', fixture.hasBranch) + '#file-cd',
+        expected(`https://gist.github.com/${expectedHash}`, fixture.hasBranch) + '#file-cd',
         showLabel(fixture.label, "browse('C/D', 'A')")
       )
       tt.end()
@@ -103,7 +104,7 @@ var testFixtures = function (t, params, fixtures) {
     t.test('hostinfo.bugs', function (tt) {
       tt.is(
         hostinfo.bugs(),
-        'https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2',
+        `https://gist.github.com/${expectedHash}`,
         showLabel(fixture.label, 'bugs')
       )
       tt.end()
@@ -116,7 +117,7 @@ var testFixtures = function (t, params, fixtures) {
       }
       tt.is(
         hostinfo.docs(),
-        expected('https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2', fixture.hasBranch),
+        expected(`https://gist.github.com/${expectedHash}`, fixture.hasBranch),
         showLabel(fixture.label, 'docs')
       )
       tt.end()
@@ -129,7 +130,7 @@ var testFixtures = function (t, params, fixtures) {
       }
       tt.is(
         hostinfo.ssh(),
-        expected('git@gist.github.com:/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git', fixture.hasBranch),
+        expected(`git@gist.github.com:/${expectedHash}.git`, fixture.hasBranch),
         showLabel(fixture.label, 'ssh')
       )
       tt.end()
@@ -142,7 +143,7 @@ var testFixtures = function (t, params, fixtures) {
       }
       tt.is(
         hostinfo.sshurl(),
-        expected('git+ssh://git@gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git', fixture.hasBranch),
+        expected(`git+ssh://git@gist.github.com/${expectedHash}.git`, fixture.hasBranch),
         showLabel(fixture.label, 'sshurl')
       )
       tt.end()
@@ -155,7 +156,7 @@ var testFixtures = function (t, params, fixtures) {
       }
       tt.is(
         hostinfo.shortcut(),
-        expected('gist:a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2', fixture.hasBranch),
+        expected(`gist:${expectedHash}`, fixture.hasBranch),
         showLabel(fixture.label, 'shortcut')
       )
       tt.end()
@@ -169,27 +170,27 @@ var testFixtures = function (t, params, fixtures) {
         }
         tt.is(
           hostinfo.file(),
-          expected('https://gist.githubusercontent.com/some-owner/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2/raw/', fixture.hasBranch),
+          expected(`https://gist.githubusercontent.com/some-owner/${expectedHash}/raw/`, fixture.hasBranch),
           showLabel(fixture.label, 'file')
         )
         tt.is(
           hostinfo.file(''),
-          expected('https://gist.githubusercontent.com/some-owner/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2/raw/', fixture.hasBranch),
+          expected(`https://gist.githubusercontent.com/some-owner/${expectedHash}/raw/`, fixture.hasBranch),
           showLabel(fixture.label, "file('')")
         )
         tt.is(
           hostinfo.file('C'),
-          expected('https://gist.githubusercontent.com/some-owner/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2/raw/', fixture.hasBranch) + 'C',
+          expected(`https://gist.githubusercontent.com/some-owner/${expectedHash}/raw/`, fixture.hasBranch) + 'C',
           showLabel(fixture.label, "file('C')")
         )
         tt.is(
           hostinfo.file('C/D'),
-          expected('https://gist.githubusercontent.com/some-owner/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2/raw/', fixture.hasBranch) + 'C/D',
+          expected(`https://gist.githubusercontent.com/some-owner/${expectedHash}/raw/`, fixture.hasBranch) + 'C/D',
           showLabel(fixture.label, "file('C/D')")
         )
         tt.is(
           hostinfo.file('C', 'A'),
-          expected('https://gist.githubusercontent.com/some-owner/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2/raw/', fixture.hasBranch) + 'C',
+          expected(`https://gist.githubusercontent.com/some-owner/${expectedHash}/raw/`, fixture.hasBranch) + 'C',
           showLabel(fixture.label, "file('C', 'A')")
         )
         tt.end()
@@ -202,12 +203,12 @@ var testFixtures = function (t, params, fixtures) {
         }
         tt.is(
           hostinfo.tarball(),
-          expected('https://codeload.github.com/gist/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2/tar.gz/master', fixture.hasBranch),
+          expected(`https://codeload.github.com/gist/${expectedHash}/tar.gz/master`, fixture.hasBranch),
           showLabel(fixture.label, 'tarball')
         )
         tt.is(
           hostinfo.tarball({ noCommittish: true }),
-          expected('https://codeload.github.com/gist/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2/tar.gz/master', fixture.hasBranch),
+          expected(`https://codeload.github.com/gist/${expectedHash}/tar.gz/master`, fixture.hasBranch),
           showLabel(fixture.label, 'tarball({ noCommittish: true })')
         )
         tt.end()
@@ -222,7 +223,7 @@ var testFixtures = function (t, params, fixtures) {
       }
       tt.is(
         hostinfo.toString(),
-        expected('git+https://gist.github.com/a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2.git', fixture.hasBranch),
+        expected(`git+https://gist.github.com/${expectedHash}.git`, fixture.hasBranch),
         showLabel(fixture.label, 'toString')
       )
       tt.end()
@@ -242,6 +243,20 @@ test('fromUrl(gist url)', function (t) {
       label: 'github',
       owner: 'some-owner',
       project: new Array(17).join('a2'),
+      branch: 'feature-branch'
+    }
+
+    testFixtures(tt, params, collectedFixtures)
+    tt.end()
+  })
+
+  t.test('legacy gist hash length', function (tt) {
+    var params = {
+      domain: 'gist.github.com',
+      shortname: 'github',
+      label: 'github',
+      owner: 'some-owner',
+      project: '3135914',
       branch: 'feature-branch'
     }
 


### PR DESCRIPTION
In a previous refactor we add a length count to strict a little bit more
the regex that identifies gists, unfortunately it drops support to
legacy gists that had less than 32 characters hashes,
ref: https://github.com/npm/hosted-git-info/commit/d5cf8309be7af884032616c63ea302ce49dd321c

This changeset fixes it by reducing that count to 7 (which is the
smallest hash length found in tests from our package ecosystem) that
seems to have been in use until at least late-2012.
