### PR TITLE
fix: correctly filter out urls for tarballs in gitlab

### DIFF
--- a/git-host-info.js
+++ b/git-host-info.js
@@ -25,7 +25,7 @@ var gitHosts = module.exports = {
     'bugstemplate': 'https://{domain}/{user}/{project}/issues',
     'httpstemplate': 'git+https://{auth@}{domain}/{user}/{projectPath}.git{#committish}',
     'tarballtemplate': 'https://{domain}/{user}/{project}/repository/archive.tar.gz?ref={committish}',
-    'pathmatch': /^[/]([^/]+)[/]((?!.*(\/-\/|\/repository\/archive\.tar\.gz\?=.*|\/repository\/[^/]+\/archive.tar.gz$)).*?)(?:[.]git|[/])?$/
+    'pathmatch': /^\/([^/]+)\/((?!.*(\/-\/|\/repository(\/[^/]+)?\/archive\.tar\.gz)).*?)(?:\.git|\/)?$/
   },
   gist: {
     'protocols': [ 'git', 'git+ssh', 'git+https', 'ssh', 'https' ],

--- a/test/fixtures/gitlab.js
+++ b/test/fixtures/gitlab.js
@@ -25,6 +25,16 @@ module.exports = [
     isUndefined: true
   },
   {
+    host: function (p) { return 'https://' + p.domain + '/' + p.owner + '/' + p.project + '/repository/archive.tar.gz?ref=' + p.branch },
+    label: 'https.tar',
+    isUndefined: true
+  },
+  {
+    host: function (p) { return 'https://' + p.domain + '/' + p.owner + '/' + p.project + '/repository/archive.tar.gz' },
+    label: 'https.tar',
+    isUndefined: true
+  },
+  {
     host: function (p) { return 'git+https://' + p.domain + '/' + p.owner + '/' + p.project },
     label: 'git+https'
   },

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -17,7 +17,7 @@ var testFixtures = function (t, params, fixtures) {
         tt.is(hostinfo, undefined)
         tt.end()
       })
-      break
+      continue
     }
 
     t.test('hostinfo.https', function (tt) {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The previous regular expression was misbehaving in some cases causing this module to return that a tarball url was a valid git host, this resolves that problem.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/1963
