### PR TITLE
Replace `lru-cache` with `quick-lru`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 var url = require('url')
 var gitHosts = require('./git-host-info.js')
 var GitHost = module.exports = require('./git-host.js')
-var LRU = require('lru-cache')
-var cache = new LRU({max: 1000})
+var LRU = require('quick-lru')
+var cache = new LRU({maxSize: 1000})
 
 var protocolToRepresentationMap = {
   'git+ssh:': 'sshurl',

--- a/package-lock.json
+++ b/package-lock.json
@@ -424,6 +424,14 @@
         "camelcase": "^4.1.0",
         "map-obj": "^2.0.0",
         "quick-lru": "^1.0.0"
+      },
+      "dependencies": {
+        "quick-lru": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+          "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+          "dev": true
+        }
       }
     },
     "capture-stack-trace": {
@@ -2766,14 +2774,6 @@
         "signal-exit": "^3.0.0"
       }
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -3613,10 +3613,9 @@
       "dev": true
     },
     "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-      "dev": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "react-is": {
       "version": "16.8.6",
@@ -4690,11 +4689,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yapool": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "tap -J --100 --no-esm test/*.js"
   },
   "dependencies": {
-    "lru-cache": "^6.0.0"
+    "quick-lru": "^5.1.1"
   },
   "devDependencies": {
     "standard": "^11.0.1",


### PR DESCRIPTION
`quick-lru` is:
- equivalent
- still trusted and maintained (by Sindre Sorhus)
- **almost 6x smaller**: [quick-lru](https://bundlephobia.com/result?p=quick-lru@5.1.1) vs [lru-cache](https://bundlephobia.com/result?p=lru-cache@6.0.0)
- **faster**, according to https://github.com/dominictarr/bench-lru
- with the same Node 10 compatibility:

https://github.com/npm/hosted-git-info/blob/afe280820d6c5f76fba40a2dfd7e899d3be526f3/package.json#L44

https://github.com/sindresorhus/quick-lru/blob/9a5f1c021a100be5aa3a47cfe6c5a5c25b38d84e/package.json#L14