### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 sudo: false
 node_js:
   - "12"


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The Travis-CI build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/hosted-git-info
Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.
Please have a look.

Thank you