### PR TITLE
fix: paper over errors from legacy parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,14 @@ function parseGitUrl (giturl) {
       const authmatch = giturl.match(/[^@]+@[^:/]+/)
       /* istanbul ignore else - this should be impossible */
       if (authmatch) {
-        var whatwg = new url.URL(authmatch[0])
+        var whatwg
+        try {
+          whatwg = new url.URL(authmatch[0])
+        } catch (e) {
+          /* istanbul ignore if - this should be impossible */
+          if (e.name !== 'TypeError') throw e
+          whatwg = {}
+        }
         legacy.auth = whatwg.username || ''
         if (whatwg.password) legacy.auth += ':' + whatwg.password
       }

--- a/test/basic.js
+++ b/test/basic.js
@@ -21,6 +21,7 @@ test('basic', function (t) {
   t.is(HostedGit.fromUrl('git://nothosted.com'), undefined, 'non-hosted empty URLs get undefined response')
   t.is(HostedGit.fromUrl('git://github.com/balderdashy/waterline-%s.git'), undefined, 'invalid URLs get undefined response')
   t.is(HostedGit.fromUrl('git://github.com'), undefined, 'Invalid hosted URLs get undefined response')
+  t.is(HostedGit.fromUrl('6:thing@thing'), undefined, 'Invalid hosted URLs get undefined response')
 
   t.is(HostedGit.fromUrl('dEf/AbC').https(), 'git+https://github.com/dEf/AbC.git', 'mixed case shortcut')
   t.is(HostedGit.fromUrl('gitlab:dEf/AbC').https(), 'git+https://gitlab.com/dEf/AbC.git', 'mixed case prefixed shortcut')


### PR DESCRIPTION
This input causes the parser to throw internally, instead of returning
undefined as documented. As re-inventing the URL class seems insane,
call the URL constructor and just discard the error it throws. Shame
about the coverage warning, don't feel that that should just discard any
possible error.

'6:thing@thing'