### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var info = hostedGitInfo.fromUrl("git@github.com:npm/hosted-git-info.git", opts)
 If the URL can't be matched with a git host, `null` will be returned.  We
 can match git, ssh and https urls.  Additionally, we can match ssh connect
 strings (`git@github.com:npm/hosted-git-info`) and shortcuts (eg,
-`github:npm/hosted-git-info`).  Github specifically, is detected in the case
+`github:npm/hosted-git-info`).  GitHub specifically, is detected in the case
 of a third, unprefixed, form: `npm/hosted-git-info`.
 
 If it does match, the returned object has properties of:
@@ -129,5 +129,5 @@ SSH connect strings will be normalized into `git+ssh` URLs.
 
 ## Supported hosts
 
-Currently this supports Github, Bitbucket and Gitlab. Pull requests for
+Currently this supports GitHub, Bitbucket and GitLab. Pull requests for
 additional hosts welcome.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hosted-git-info",
   "version": "3.0.8",
-  "description": "Provides metadata and conversions from repository urls for Github, Bitbucket and Gitlab",
+  "description": "Provides metadata and conversions from repository urls for GitHub, Bitbucket and GitLab",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/test/fixtures/github.js
+++ b/test/fixtures/github.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = [
-  // Github Shorturls
+  // GitHub Shorturls
   {
     host: function (p) { return p.owner + '/' + p.project },
     label: 'github-short'


### PR DESCRIPTION
Minor capitalization fix: `Github` -> `GitHub`