### PR TITLE
fix: account for extreme github shorthand in input that ends with a / as part of the committish

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,8 @@ const isGitHubShorthand = (arg) => {
   const colonOnlyAfterHash = firstColon === -1 || (firstHash > -1 && firstColon > firstHash)
   const secondSlashOnlyAfterHash = secondSlash === -1 || (firstHash > -1 && secondSlash > firstHash)
   const hasSlash = firstSlash > 0
-  const doesNotEndWithSlash = !arg.endsWith('/')
+  // if a # is found, what we really want to know is that the character immediately before # is not a /
+  const doesNotEndWithSlash = firstHash > -1 ? arg[firstHash - 1] !== '/' : !arg.endsWith('/')
   const doesNotStartWithDot = !arg.startsWith('.')
 
   return spaceOnlyAfterHash && hasSlash && doesNotEndWithSlash && doesNotStartWithDot && atOnlyAfterHash && colonOnlyAfterHash && secondSlashOnlyAfterHash

--- a/test/github.js
+++ b/test/github.js
@@ -8,6 +8,8 @@ const invalid = [
   ':password@foo/bar',
   // foo/bar shorthand but with a space in it
   'foo/ bar',
+  // string that ends with a slash, probably a directory
+  'foo/bar/',
   // git@github.com style, but omitting the username
   'github.com:foo/bar',
   'github.com/foo/bar',
@@ -179,7 +181,8 @@ const valid = {
   // inputs that are not quite proper but we accept anyway
   'https://www.github.com/foo/bar': { ...defaults, default: 'https' },
   'foo/bar#branch with space': { ...defaults, default: 'shortcut', committish: 'branch with space' },
-  'https://github.com/foo/bar/tree/branch': { ...defaults, default: 'https', committish: 'branch' }
+  'https://github.com/foo/bar/tree/branch': { ...defaults, default: 'https', committish: 'branch' },
+  'user..blerg--/..foo-js# . . . . . some . tags / / /': { ...defaults, default: 'shortcut', user: 'user..blerg--', project: '..foo-js', committish: ' . . . . . some . tags / / /' }
 }
 
 t.test('valid urls parse properly', t => {


### PR DESCRIPTION
test input lifted from npm-package-arg

