### PR TITLE
fix: do not parse tarball urls for gitlab

### DIFF
--- a/git-host-info.js
+++ b/git-host-info.js
@@ -79,7 +79,7 @@ gitHosts.gitlab = Object.assign({}, defaults, {
   tarballtemplate: ({ domain, user, project, committish }) => `https://${domain}/${user}/${project}/repository/archive.tar.gz?ref=${maybeEncode(committish) || 'master'}`,
   extract: (url) => {
     const path = url.pathname.slice(1)
-    if (path.includes('/-/')) {
+    if (path.includes('/-/') || path.includes('/archive.tar.gz')) {
       return
     }
 

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -6,7 +6,10 @@ const invalid = [
   // gitlab urls can contain a /-/ segment, make sure we ignore those
   'https://gitlab.com/foo/-/something',
   // missing project
-  'https://gitlab.com/foo'
+  'https://gitlab.com/foo',
+  // tarball, this should not parse so that it can be used for pacote's remote fetcher
+  'https://gitlab.com/foo/bar/repository/archive.tar.gz',
+  'https://gitlab.com/foo/bar/repository/archive.tar.gz?ref=49b393e2ded775f2df36ef2ffcb61b0359c194c9'
 ]
 
 // assigning the constructor here is hacky, but the only way to make assertions that compare


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
the tarball url is passed to the remote fetcher in pacote, which runs it through npm-package-arg to get a spec a second time. if this result is of any type other than 'remote' pacote will throw an error. in order to avoid this, we need to be sure that the tarball url generated does not parse back through ourselves as a git dependency.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/2939