### PR TITLE
fix: only correct protocols when called from githost

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ const LRU = require('lru-cache')
 const hosts = require('./hosts.js')
 const fromUrl = require('./from-url.js')
 const parseUrl = require('./parse-url.js')
-const getProtocols = require('./protocols.js')
 
 const cache = new LRU({ max: 1000 })
 
@@ -22,7 +21,15 @@ class GitHost {
   }
 
   static #gitHosts = { byShortcut: {}, byDomain: {} }
-  static #protocols = getProtocols()
+  static #protocols = {
+    'git+ssh:': { name: 'sshurl' },
+    'ssh:': { name: 'sshurl' },
+    'git+https:': { name: 'https', auth: true },
+    'git:': { auth: true },
+    'http:': { auth: true },
+    'https:': { auth: true },
+    'git+http:': { auth: true },
+  }
 
   static addHost (name, host) {
     GitHost.#gitHosts[name] = host

--- a/lib/parse-url.js
+++ b/lib/parse-url.js
@@ -1,5 +1,4 @@
 const url = require('url')
-const getProtocols = require('./protocols.js')
 
 const lastIndexOfBefore = (str, char, beforeChar) => {
   const startPosition = str.indexOf(beforeChar)
@@ -73,7 +72,7 @@ const correctUrl = (giturl) => {
   return giturl
 }
 
-module.exports = (giturl, protocols = getProtocols()) => {
-  const withProtocol = correctProtocol(giturl, protocols)
+module.exports = (giturl, protocols) => {
+  const withProtocol = protocols ? correctProtocol(giturl, protocols) : giturl
   return safeUrl(withProtocol) || safeUrl(correctUrl(withProtocol))
 }

--- a/lib/protocols.js
+++ b/lib/protocols.js
@@ -1,9 +1,0 @@
-module.exports = () => ({
-  'git+ssh:': { name: 'sshurl' },
-  'ssh:': { name: 'sshurl' },
-  'git+https:': { name: 'https', auth: true },
-  'git:': { auth: true },
-  'http:': { auth: true },
-  'https:': { auth: true },
-  'git+http:': { auth: true },
-})

--- a/test/parse-url.js
+++ b/test/parse-url.js
@@ -2,9 +2,16 @@ const t = require('tap')
 const HostedGit = require('..')
 const parseUrl = require('../lib/parse-url.js')
 
-t.test('can parse git+ssh url by default', async t => {
+t.test('can parse git+ssh urls', async t => {
   // https://github.com/npm/cli/issues/5278
   const u = 'git+ssh://git@abc:frontend/utils.git#6d45447e0c5eb6cd2e3edf05a8c5a9bb81950c79'
+  t.ok(parseUrl(u))
+  t.ok(HostedGit.parseUrl(u))
+})
+
+t.test('can parse file urls', async t => {
+  // https://github.com/npm/cli/pull/5758#issuecomment-1292753331
+  const u = 'file:../../../global-prefix/lib/node_modules/@myscope/bar'
   t.ok(parseUrl(u))
   t.ok(HostedGit.parseUrl(u))
 })


### PR DESCRIPTION
Now that `hosted-git-info` can be used to only parse a url, it should do so without treating any protocols in a special way. When called via `hosted-git-info.fromUrl` it will still pass in the object of preferred protocols, but when called via `hosted-git-info.parseUrl` it will accept all protocols, so that urls like `file:../etc` can be parsed.

Ref: https://github.com/npm/cli/pull/5758

Also landing in `v5` via #177.