### PR TITLE
fix: remove sourcehut bugstemplate

### DIFF
--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -199,8 +199,7 @@ hosts.sourcehut = {
     `https://${domain}/${user}/${project}.git${maybeJoin('#', committish)}`,
   tarballtemplate: ({ domain, user, project, committish }) =>
     `https://${domain}/${user}/${project}/archive/${maybeEncode(committish) || 'HEAD'}.tar.gz`,
-  bugstemplate: ({ user, project }) =>
-    `https://todo.sr.ht/${user}/${project}`,
+  bugstemplate: ({ user, project }) => null,
   extract: (url) => {
     let [, user, project, aux] = url.pathname.split('/', 4)
 

--- a/test/sourcehut.js
+++ b/test/sourcehut.js
@@ -106,7 +106,7 @@ t.test('string methods populate correctly', t => {
   t.equal(parsed.tarball(), 'https://git.sr.ht/~foo/bar/archive/HEAD.tar.gz')
   t.equal(parsed.file(), 'https://git.sr.ht/~foo/bar/blob/HEAD/')
   t.equal(parsed.file('/lib/index.js'), 'https://git.sr.ht/~foo/bar/blob/HEAD/lib/index.js')
-  t.equal(parsed.bugs(), 'https://todo.sr.ht/~foo/bar')
+  t.equal(parsed.bugs(), null)
 
   t.equal(
     parsed.docs({ committish: 'fix/bug' }),


### PR DESCRIPTION
Currently, using https://git.sr.ht/~user/repo in `npm init` results in the package.json file having a `bugs` URL of
https://todo.sr.ht/~user/repo. However, this is not how SourceHut works. An issue tracker need not exist at that URL, and often projects have issue trackers that are named differently from the repository. Therefore, no information can be inferred about the issue tracker from the git URL.