### PR TITLE
fix: break up greedy host fragment parsing regex

### DIFF
--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -4,7 +4,11 @@
 
 const maybeJoin = (...args) => args.every(arg => arg) ? args.join('') : ''
 const maybeEncode = (arg) => arg ? encodeURIComponent(arg) : ''
-const formatHashFragment = (f) => f.toLowerCase().replace(/^\W+|\/|\W+$/g, '').replace(/\W+/g, '-')
+const formatHashFragment = (f) => f.toLowerCase()
+  .replace(/^\W+/g, '') // strip leading non-characters
+  .replace(/\W+$/g, '') // strip trailing non-characters
+  .replace(/\//g, '') // strip all slashes
+  .replace(/\W+/g, '-') // replace remaining non-characters with '-'
 
 const defaults = {
   sshtemplate: ({ domain, user, project, committish }) =>


### PR DESCRIPTION
It's easier to reason about each step this way, and also not susceptible
to redos.
