### PR TITLE
feat: add `HostedGitInfo.fromManifest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const info = hostedGitInfo.fromUrl("git@github.com:npm/hosted-git-info.git", opt
 */
 ```
 
-If the URL can't be matched with a git host, `null` will be returned.  We
+If the URL can't be matched with a git host, `null` will be returned. We
 can match git, ssh and https urls.  Additionally, we can match ssh connect
 strings (`git@github.com:npm/hosted-git-info`) and shortcuts (eg,
 `github:npm/hosted-git-info`).  GitHub specifically, is detected in the case
@@ -58,6 +58,11 @@ Implications:
 * *options* is an optional object. It can have the following properties:
   * *noCommittish* — If true then committishes won't be included in generated URLs.
   * *noGitPlus* — If true then `git+` won't be prefixed on URLs.
+
+### const infoOrURL = hostedGitInfo.fromManifest(manifest[, options])
+
+* *manifest* is a package manifest, such as that returned by [`pacote.manifest()`](https://npmjs.com/pacote)
+* *options* is an optional object. It can have the same properties as `fromUrl` above.
 
 ## Methods
 

--- a/test/file.js
+++ b/test/file.js
@@ -1,0 +1,14 @@
+const HostedGit = require('..')
+const t = require('tap')
+
+t.test('file:// URLs', t => {
+  const fileRepo = {
+    name: 'foo',
+    repository: {
+      url: 'file:///path/dot.git',
+    },
+  }
+  t.equal(HostedGit.fromManifest(fileRepo), null)
+
+  t.end()
+})

--- a/test/github.js
+++ b/test/github.js
@@ -270,3 +270,80 @@ t.test('string methods populate correctly', t => {
 
   t.end()
 })
+
+t.test('from manifest', t => {
+  t.equal(HostedGit.fromManifest(), undefined, 'no manifest returns undefined')
+  t.equal(HostedGit.fromManifest(), undefined, 'no manifest returns undefined')
+  t.equal(HostedGit.fromManifest(false), undefined, 'false manifest returns undefined')
+  t.equal(HostedGit.fromManifest(() => {}), undefined, 'function manifest returns undefined')
+
+  const unknownHostRepo = {
+    name: 'foo',
+    repository: {
+      url: 'https://nope.com',
+    },
+  }
+  t.same(HostedGit.fromManifest(unknownHostRepo), 'https://nope.com/')
+
+  const insecureUnknownHostRepo = {
+    name: 'foo',
+    repository: {
+      url: 'http://nope.com',
+    },
+  }
+  t.same(HostedGit.fromManifest(insecureUnknownHostRepo), 'https://nope.com/')
+
+  const insecureGitUnknownHostRepo = {
+    name: 'foo',
+    repository: {
+      url: 'git+http://nope.com',
+    },
+  }
+  t.same(HostedGit.fromManifest(insecureGitUnknownHostRepo), 'http://nope.com')
+
+  const badRepo = {
+    name: 'foo',
+    repository: {
+      url: '#',
+    },
+  }
+  t.equal(HostedGit.fromManifest(badRepo), null)
+
+  const manifest = {
+    name: 'foo',
+    repository: {
+      type: 'git',
+      url: 'git+ssh://github.com/foo/bar.git',
+    },
+  }
+
+  const parsed = HostedGit.fromManifest(manifest)
+  t.same(parsed.browse(), 'https://github.com/foo/bar')
+
+  const monorepo = {
+    name: 'clowncar',
+    repository: {
+      type: 'git',
+      url: 'git+ssh://github.com/foo/bar.git',
+      directory: 'packages/foo',
+    },
+  }
+
+  const honk = HostedGit.fromManifest(monorepo)
+  t.same(honk.browse(monorepo.repository.directory), 'https://github.com/foo/bar/tree/HEAD/packages/foo')
+
+  const stringRepo = {
+    name: 'foo',
+    repository: 'git+ssh://github.com/foo/bar.git',
+  }
+  const stringRepoParsed = HostedGit.fromManifest(stringRepo)
+  t.same(stringRepoParsed.browse(), 'https://github.com/foo/bar')
+
+  const nonStringRepo = {
+    name: 'foo',
+    repository: 42,
+  }
+  t.throws(() => HostedGit.fromManifest(nonStringRepo))
+
+  t.end()
+})


### PR DESCRIPTION
This encapsulates the logic used in `npm repo`

Per Slack discussion. Once this is published and updated in the cli, I'll happily adapt the `npm repo` code to use this method.

The method will either return a HGI instance, a string URL, or `null`.