### PR TITLE
fix: remove redundant httpstemplate

### DIFF
--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -109,8 +109,6 @@ hosts.gitlab = {
   treepath: 'tree',
   blobpath: 'tree',
   editpath: '-/edit',
-  httpstemplate: ({ auth, domain, user, project, committish }) =>
-    `git+https://${maybeJoin(auth, '@')}${domain}/${user}/${project}.git${maybeJoin('#', committish)}`,
   tarballtemplate: ({ domain, user, project, committish }) =>
     `https://${domain}/${user}/${project}/repository/archive.tar.gz?ref=${maybeEncode(committish || 'HEAD')}`,
   extract: (url) => {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Hey, y'all. It seems to me that the `httpstemplate` for Gitlab is redundant since it appears identical to the default.

I ran tests locally and they seem to pass.
<img width="611" height="814" alt="image" src="https://github.com/user-attachments/assets/129bc4c6-c34b-47ac-947f-465d42f47315" />
