### PR TITLE
fix: remove .git suffix from Sourcehut https URLs

### DIFF
--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -198,7 +198,7 @@ hosts.sourcehut = {
   filetemplate: ({ domain, user, project, committish, path }) =>
     `https://${domain}/${user}/${project}/blob/${maybeEncode(committish) || 'HEAD'}/${path}`,
   httpstemplate: ({ domain, user, project, committish }) =>
-    `https://${domain}/${user}/${project}.git${maybeJoin('#', committish)}`,
+    `https://${domain}/${user}/${project}${maybeJoin('#', committish)}`,
   tarballtemplate: ({ domain, user, project, committish }) =>
     `https://${domain}/${user}/${project}/archive/${maybeEncode(committish) || 'HEAD'}.tar.gz`,
   bugstemplate: () => null,

--- a/test/sourcehut.js
+++ b/test/sourcehut.js
@@ -105,7 +105,7 @@ test('string methods populate correctly', () => {
     'https://git.sr.ht/~foo/bar/tree/HEAD/lib/index.js#l100'
   )
   assert.strictEqual(parsed.docs(), 'https://git.sr.ht/~foo/bar#readme')
-  assert.strictEqual(parsed.https(), 'https://git.sr.ht/~foo/bar.git')
+  assert.strictEqual(parsed.https(), 'https://git.sr.ht/~foo/bar')
   assert.strictEqual(parsed.shortcut(), 'sourcehut:~foo/bar')
   assert.strictEqual(parsed.path(), '~foo/bar')
   assert.strictEqual(parsed.tarball(), 'https://git.sr.ht/~foo/bar/archive/HEAD.tar.gz')
@@ -123,7 +123,7 @@ test('string methods populate correctly', () => {
 
   const extra = HostedGit.fromUrl('https://@git.sr.ht/~foo/bar#fix/bug')
   assert.strictEqual(extra.hash(), '#fix/bug')
-  assert.strictEqual(extra.https(), 'https://git.sr.ht/~foo/bar.git#fix/bug')
+  assert.strictEqual(extra.https(), 'https://git.sr.ht/~foo/bar#fix/bug')
   assert.strictEqual(extra.shortcut(), 'sourcehut:~foo/bar#fix/bug')
   assert.strictEqual(extra.ssh(), 'git@git.sr.ht:~foo/bar.git#fix/bug')
   assert.strictEqual(extra.sshurl(), 'git+ssh://git@git.sr.ht/~foo/bar.git#fix/bug')


### PR DESCRIPTION
Sourcehut 404s on HTTPS URLs ending in `.git` (unlike GitHub/GitLab/Bitbucket), so `httpstemplate` was producing invalid clone URLs.

Fixes https://github.com/npm/cli/issues/9174