### PR TITLE
fix: use GitLab API v4 endpoint for tarball URLs

### DIFF
--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -110,7 +110,7 @@ hosts.gitlab = {
   blobpath: 'tree',
   editpath: '-/edit',
   tarballtemplate: ({ domain, user, project, committish }) =>
-    `https://${domain}/${user}/${project}/repository/archive.tar.gz?ref=${maybeEncode(committish || 'HEAD')}`,
+    `https://${domain}/api/v4/projects/${maybeEncode(user + '/' + project)}/repository/archive.tar.gz?sha=${maybeEncode(committish || 'HEAD')}`,
   extract: (url) => {
     const path = url.pathname.slice(1)
     if (path.includes('/-/') || path.includes('/archive.tar.gz')) {

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -17,8 +17,8 @@ const invalid = [
   // missing project
   'https://gitlab.com/foo',
   // tarball, this should not parse so that it can be used for pacote's remote fetcher
-  'https://gitlab.com/foo/bar/repository/archive.tar.gz',
-  'https://gitlab.com/foo/bar/repository/archive.tar.gz?ref=49b393e2ded775f2df36ef2ffcb61b0359c194c9',
+  'https://gitlab.com/api/v4/projects/foo%2Fbar/repository/archive.tar.gz',
+  'https://gitlab.com/api/v4/projects/foo%2Fbar/repository/archive.tar.gz?sha=49b393e2ded775f2df36ef2ffcb61b0359c194c9',
 ]
 
 const defaults = { type: 'gitlab', user: 'foo', project: 'bar' }
@@ -298,7 +298,7 @@ test('string methods populate correctly', () => {
   assert.strictEqual(parsed.https(), 'git+https://gitlab.com/foo/bar.git')
   assert.strictEqual(parsed.shortcut(), 'gitlab:foo/bar')
   assert.strictEqual(parsed.path(), 'foo/bar')
-  assert.strictEqual(parsed.tarball(), 'https://gitlab.com/foo/bar/repository/archive.tar.gz?ref=HEAD')
+  assert.strictEqual(parsed.tarball(), 'https://gitlab.com/api/v4/projects/foo%2Fbar/repository/archive.tar.gz?sha=HEAD')
   assert.strictEqual(parsed.file(), 'https://gitlab.com/foo/bar/raw/HEAD/')
   assert.strictEqual(parsed.file('/lib/index.js'), 'https://gitlab.com/foo/bar/raw/HEAD/lib/index.js')
   assert.strictEqual(parsed.bugs(), 'https://gitlab.com/foo/bar/issues')
@@ -319,7 +319,10 @@ test('string methods populate correctly', () => {
   assert.strictEqual(extra.docs(), 'https://gitlab.com/foo/bar/tree/fix%2Fbug#readme')
   assert.strictEqual(extra.file(), 'https://gitlab.com/foo/bar/raw/fix%2Fbug/')
   assert.strictEqual(extra.file('/lib/index.js'), 'https://gitlab.com/foo/bar/raw/fix%2Fbug/lib/index.js')
-  assert.strictEqual(extra.tarball(), 'https://gitlab.com/foo/bar/repository/archive.tar.gz?ref=fix%2Fbug')
+  assert.strictEqual(extra.tarball(), 'https://gitlab.com/api/v4/projects/foo%2Fbar/repository/archive.tar.gz?sha=fix%2Fbug')
+
+  const subgroupParsed = HostedGit.fromUrl('git+ssh://gitlab.com/foo/bar/baz')
+  assert.strictEqual(subgroupParsed.tarball(), 'https://gitlab.com/api/v4/projects/foo%2Fbar%2Fbaz/repository/archive.tar.gz?sha=HEAD')
 
   assert.strictEqual(extra.sshurl({ noCommittish: true }), 'git+ssh://git@gitlab.com/foo/bar.git', 'noCommittish drops committish from urls')
   assert.strictEqual(extra.sshurl({ noGitPlus: true }), 'ssh://git@gitlab.com/foo/bar.git#fix/bug', 'noGitPlus drops git+ prefix from urls')


### PR DESCRIPTION
### What / Why 

The GitLab endpoint `repository/archive` was deprecated in 2021 - https://gitlab.com/gitlab-org/gitlab/-/merge_requests/57236.

The tarball workflow has not been working since then.

This change updates the tarball request path from the deprecated endpoint to the REST API archive endpoint: https://docs.gitlab.com/api/repositories/#retrieve-file-archive-from-a-repository.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
