### PR TITLE
feat: add Codeberg host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,5 @@ SSH connect strings will be normalized into `git+ssh` URLs.
 
 ## Supported hosts
 
-Currently this supports GitHub (including Gists), Bitbucket, GitLab and Sourcehut.
+Currently this supports GitHub (including Gists), Bitbucket, GitLab, Sourcehut and Codeberg.
 Pull requests for additional hosts welcome.

--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -222,6 +222,32 @@ hosts.sourcehut = {
   },
 }
 
+hosts.codeberg = {
+  protocols: ['git+ssh:', 'git+https:', 'ssh:', 'https:'],
+  domain: 'codeberg.org',
+  treepath: 'src',
+  blobpath: 'src',
+  editpath: '_edit',
+  tarballtemplate: ({ domain, user, project, committish }) =>
+    `https://${domain}/${user}/${project}/archive/${maybeEncode(committish || 'HEAD')}.tar.gz`,
+  extract: (url) => {
+    let [, user, project, aux] = url.pathname.split('/', 4)
+    if (['archive', 'issues', 'pulls', 'src', 'raw', '_edit'].includes(aux)) {
+      return
+    }
+
+    if (project && project.endsWith('.git')) {
+      project = project.slice(0, -4)
+    }
+
+    if (!user || !project) {
+      return
+    }
+
+    return { user, project, committish: url.hash.slice(1) }
+  },
+}
+
 for (const [name, host] of Object.entries(hosts)) {
   hosts[name] = Object.assign({}, defaults, host)
 }

--- a/test/codeberg.js
+++ b/test/codeberg.js
@@ -1,0 +1,45 @@
+'use strict'
+const { test } = require('node:test')
+const assert = require('node:assert')
+const HostedGit = require('..')
+
+test('Codeberg URLs parse and generate Forgejo links', () => {
+  const info = HostedGit.fromUrl('https://codeberg.org/forgejo/forgejo#v9.0.0')
+
+  assert.strictEqual(info.type, 'codeberg')
+  assert.strictEqual(info.user, 'forgejo')
+  assert.strictEqual(info.project, 'forgejo')
+  assert.strictEqual(info.committish, 'v9.0.0')
+  assert.strictEqual(info.default, 'https')
+  assert.strictEqual(info.https(), 'git+https://codeberg.org/forgejo/forgejo.git#v9.0.0')
+  assert.strictEqual(info.ssh(), 'git@codeberg.org:forgejo/forgejo.git#v9.0.0')
+  assert.strictEqual(info.sshurl(), 'git+ssh://git@codeberg.org/forgejo/forgejo.git#v9.0.0')
+  assert.strictEqual(info.browse('/README.md'), 'https://codeberg.org/forgejo/forgejo/src/v9.0.0/README.md')
+  assert.strictEqual(info.file('/README.md'), 'https://codeberg.org/forgejo/forgejo/raw/v9.0.0/README.md')
+  assert.strictEqual(info.tarball(), 'https://codeberg.org/forgejo/forgejo/archive/v9.0.0.tar.gz')
+  assert.strictEqual(info.bugs(), 'https://codeberg.org/forgejo/forgejo/issues')
+})
+
+test('Codeberg repository pages are not treated as repository URLs', () => {
+  for (const url of [
+    'https://codeberg.org/forgejo/forgejo/src/branch/main',
+    'https://codeberg.org/forgejo/forgejo/issues',
+    'https://codeberg.org/forgejo/forgejo/archive/main.tar.gz',
+  ]) {
+    assert.strictEqual(HostedGit.fromUrl(url), undefined, `${url} returns undefined`)
+  }
+
+  for (const url of ['https://codeberg.org/forgejo', 'https://codeberg.org/']) {
+    assert.strictEqual(HostedGit.fromUrl(url), undefined)
+  }
+})
+
+test('Codeberg clone URLs without a committish accept a .git suffix', () => {
+  const info = HostedGit.fromUrl('git@codeberg.org:forgejo/forgejo.git')
+
+  assert.strictEqual(info.type, 'codeberg')
+  assert.strictEqual(info.user, 'forgejo')
+  assert.strictEqual(info.project, 'forgejo')
+  assert.strictEqual(info.default, 'sshurl')
+  assert.strictEqual(info.tarball(), 'https://codeberg.org/forgejo/forgejo/archive/HEAD.tar.gz')
+})


### PR DESCRIPTION
Fixes #117.

Add Codeberg URL parsing and Forgejo-compatible browse, edit, and archive URL generation. Repository pages such as issues, pulls, source, raw, edit, and archive paths are rejected as clone URLs, and `.git` suffixes are normalized. Documentation and focused regression tests are included.

Tests: 31 passed; 100% line/branch/function coverage; ESLint and template checks passed.